### PR TITLE
Allow config

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,19 +31,21 @@ async function main() {
       console.log(`Loaded ${comments.length} existing comments from ${config.paths.commentsFile}`);
       
       // Ask if user wants to regenerate comments
-      const rl = readline.createInterface({
-        input: process.stdin,
-        output: process.stdout
-      });
-      
-      const answer = await new Promise(resolve => {
-        rl.question('Do you want to regenerate comments? (y/n): ', resolve);
-      });
-      
-      rl.close();
-      
-      if (answer.toLowerCase() === 'y') {
-        comments = await generateComments();
+      if (config.generator.allowRegenerateComments) {
+        const rl = readline.createInterface({
+          input: process.stdin,
+          output: process.stdout
+        });
+
+        await new Promise(resolve => {
+          rl.question('Do you want to regenerate comments? (y/n): ', resolve);
+        });
+
+        rl.close();
+
+        if (answer.toLowerCase() === 'y') {
+          comments = await generateComments();
+        }
       }
     } catch (error) {
       // Generate new comments if file doesn't exist or is invalid

--- a/src/config.js
+++ b/src/config.js
@@ -5,16 +5,16 @@
 export default {
   // Model configuration
   openai: {
-    baseURL: "http://localhost:12434/engines/v1", // Base URL for Docker Model Runner
+    baseURL: process.env.OPENAI_BASE_URL || "http://localhost:12434/engines/v1", // Base URL for Docker Model Runner
     apiKey: 'ignored',
-    model: "ai/gemma3", // Model to use for generation and processing
+    model: process.env.LLM_MODEL || "ai/gemma3", // Model to use for generation and processing
     commentGeneration: {
       temperature: 0.3,
       max_tokens: 250,
       n: 1,
     },
     embedding: {
-      model: "ai/mxbai-embed-large", // Model for generating embeddings
+      model: process.env.EMBEDDINGS_MODEL || "ai/mxbai-embed-large", // Model for generating embeddings
     },
   },
   

--- a/src/config.js
+++ b/src/config.js
@@ -2,6 +2,17 @@
  * Configuration settings for the Comment Processing System
  */
 
+function asBoolean(value, defaultValue) {
+  if (!value) return defaultValue;
+  if (typeof value === 'string') {
+    return value.toLowerCase() === 'true';
+  }
+  if (typeof value === 'boolean') {
+    return value;
+  }
+  return defaultValue;
+}
+
 export default {
   // Model configuration
   openai: {
@@ -20,6 +31,7 @@ export default {
   
   // Comment generation settings
   generator: {
+    allowRegenerateComments: asBoolean(process.env.ALLOW_GENERATE_COMMENTS, true),
     numComments: 20, // Number of synthetic comments to generate
     commentTypes: ["positive", "negative", "neutral"], // Types of comments to generate
     topics: [


### PR DESCRIPTION
Allow the models, OpenAI endpoint, and the ability to generate comments configurable (to setup future Compose demos)